### PR TITLE
Update usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use Rust-Crypto, add the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-rust-crypto = "^0.2"
+rust-crypto-wasm = "^0.3"
 ```
 
 and the following to your crate root:


### PR DESCRIPTION
Currently the Usage section of the README specifies how to use [rust-crypto](https://docs.rs/crate/rust-crypto/), not [rust-crypto-wasm](https://docs.rs/crate/rust-crypto-wasm/0.3.1)

I found that a bit confusing, since these instructions don't work with wasm.

This updates the README to use the correct name.