### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ cc = "^1.0.79"
 [dependencies]
 libc = { version = "^0.2", default-features = false }
 rand = "^0.3"
-base64 = "^0.5"
+base64 = "^0.21"
 hex = "^0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cc = "^1.0.79"
 
 [dependencies]
 libc = { version = "^0.2", default-features = false }
-rand = "^0.3"
+rand = "^0.4"
 getrandom = { version = "^0.2", features = ["std"] }
 base64 = "^0.21"
 hex = "^0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ cc = "^1.0.79"
 [dependencies]
 libc = { version = "^0.2", default-features = false }
 rand = "^0.3"
+getrandom = { version = "^0.2", features = ["std"] }
 base64 = "^0.21"
 hex = "^0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ cc = "^1.0.79"
 libc = { version = "^0.2", default-features = false }
 rand = "^0.3"
 base64 = "^0.5"
-hex = "^0.2"
+hex = "^0.4.3"

--- a/src/aesni_helpers.c
+++ b/src/aesni_helpers.c
@@ -71,7 +71,7 @@ void rust_crypto_aesni_setup_working_key_128(
             pxor %%xmm2, %%xmm1; \
             movdqu %%xmm1, (%0); \
             add $0x10, %0; \
-            ret; \            \
+            ret; \
             2: \
         "
     : "+r" (round_key)

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -72,10 +72,8 @@ pub trait Digest {
      * String in hexadecimal format.
      */
     fn result_str(&mut self) -> String {
-        use hex::ToHex;
-
         let mut buf: Vec<u8> = repeat(0).take((self.output_bits() + 7) / 8).collect();
         self.result(&mut buf);
-        (&buf[..]).to_hex()
+        hex::encode(&buf[..])
     }
 }

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -13,7 +13,7 @@ use cryptoutil::copy_memory;
 use std::io;
 use std::iter::repeat;
 
-use base64;
+use base64::{self, Engine};
 use rand::{OsRng, Rng};
 
 use cryptoutil::{read_u32_be, write_u32_be};
@@ -145,11 +145,11 @@ pub fn pbkdf2_simple(password: &str, c: u32) -> io::Result<String> {
     let mut result = "$rpbkdf2$0$".to_string();
     let mut tmp = [0u8; 4];
     write_u32_be(&mut tmp, c);
-    result.push_str(&base64::encode_config(&tmp, base64::STANDARD)[..]);
+    result.push_str(&base64::engine::general_purpose::STANDARD.encode(&tmp));
     result.push('$');
-    result.push_str(&base64::encode_config(&salt, base64::STANDARD)[..]);
+    result.push_str(&base64::engine::general_purpose::STANDARD.encode(&salt));
     result.push('$');
-    result.push_str(&base64::encode_config(&dk, base64::STANDARD)[..]);
+    result.push_str(&base64::engine::general_purpose::STANDARD.encode(&dk));
     result.push('$');
 
     Ok(result)
@@ -201,7 +201,7 @@ pub fn pbkdf2_check(password: &str, hashed_value: &str) -> Result<bool, &'static
 
     // Parse the iteration count
     let c = match iter.next() {
-        Some(pstr) => match base64::decode(pstr) {
+        Some(pstr) => match base64::engine::general_purpose::STANDARD.decode(pstr) {
             Ok(pvec) => {
                 if pvec.len() != 4 {
                     return Err(ERR_STR);
@@ -215,7 +215,7 @@ pub fn pbkdf2_check(password: &str, hashed_value: &str) -> Result<bool, &'static
 
     // Salt
     let salt = match iter.next() {
-        Some(sstr) => match base64::decode(sstr) {
+        Some(sstr) => match base64::engine::general_purpose::STANDARD.decode(sstr) {
             Ok(salt) => salt,
             Err(_) => return Err(ERR_STR),
         },
@@ -224,7 +224,7 @@ pub fn pbkdf2_check(password: &str, hashed_value: &str) -> Result<bool, &'static
 
     // Hashed value
     let hash = match iter.next() {
-        Some(hstr) => match base64::decode(hstr) {
+        Some(hstr) => match base64::engine::general_purpose::STANDARD.decode(hstr) {
             Ok(hash) => hash,
             Err(_) => return Err(ERR_STR),
         },

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -14,8 +14,6 @@ use std::io;
 use std::iter::repeat;
 
 use base64::{self, Engine};
-use rand::{OsRng, Rng};
-
 use cryptoutil::{read_u32_be, write_u32_be};
 use hmac::Hmac;
 use mac::Mac;
@@ -130,10 +128,9 @@ pub fn pbkdf2<M: Mac>(mac: &mut M, salt: &[u8], c: u32, output: &mut [u8]) {
  *
  */
 pub fn pbkdf2_simple(password: &str, c: u32) -> io::Result<String> {
-    let mut rng = OsRng::new()?;
-
     // 128-bit salt
-    let salt: Vec<u8> = rng.gen_iter::<u8>().take(16).collect();
+    let mut salt = [0u8, 16];
+    getrandom::getrandom(&mut salt)?;
 
     // 256-bit derived key
     let mut dk = [0u8; 32];

--- a/src/scrypt.rs
+++ b/src/scrypt.rs
@@ -19,8 +19,6 @@ use std::iter::repeat;
 use std::mem::size_of;
 
 use base64::{self, Engine};
-use rand::{OsRng, Rng};
-
 use cryptoutil::{read_u32_le, read_u32v_le, write_u32_le};
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
@@ -276,15 +274,14 @@ pub fn scrypt(password: &[u8], salt: &[u8], params: &ScryptParams, output: &mut 
  *
  */
 pub fn scrypt_simple(password: &str, params: &ScryptParams) -> io::Result<String> {
-    let mut rng = OsRng::new()?;
-
     // 128-bit salt
-    let salt: Vec<u8> = rng.gen_iter::<u8>().take(16).collect();
+    let mut salt = [0u8, 16];
+    getrandom::getrandom(&mut salt)?;
 
     // 256-bit derived key
     let mut dk = [0u8; 32];
 
-    scrypt(password.as_bytes(), &*salt, params, &mut dk);
+    scrypt(password.as_bytes(), &salt, params, &mut dk);
 
     let mut result = "$rscrypt$".to_string();
     if params.r < 256 && params.p < 256 {

--- a/src/scrypt.rs
+++ b/src/scrypt.rs
@@ -18,7 +18,7 @@ use std::io;
 use std::iter::repeat;
 use std::mem::size_of;
 
-use base64;
+use base64::{self, Engine};
 use rand::{OsRng, Rng};
 
 use cryptoutil::{read_u32_le, read_u32v_le, write_u32_le};
@@ -293,19 +293,19 @@ pub fn scrypt_simple(password: &str, params: &ScryptParams) -> io::Result<String
         tmp[0] = params.log_n;
         tmp[1] = params.r as u8;
         tmp[2] = params.p as u8;
-        result.push_str(&*base64::encode_config(&tmp, base64::STANDARD));
+        result.push_str(&*base64::engine::general_purpose::STANDARD.encode(&tmp));
     } else {
         result.push_str("1$");
         let mut tmp = [0u8; 9];
         tmp[0] = params.log_n;
         write_u32_le(&mut tmp[1..5], params.r);
         write_u32_le(&mut tmp[5..9], params.p);
-        result.push_str(&*base64::encode_config(&tmp, base64::STANDARD));
+        result.push_str(&*base64::engine::general_purpose::STANDARD.encode(&tmp));
     }
     result.push('$');
-    result.push_str(&*base64::encode_config(&salt, base64::STANDARD));
+    result.push_str(&*base64::engine::general_purpose::STANDARD.encode(&salt));
     result.push('$');
-    result.push_str(&*base64::encode_config(&dk, base64::STANDARD));
+    result.push_str(&*base64::engine::general_purpose::STANDARD.encode(&dk));
     result.push('$');
 
     Ok(result)
@@ -353,7 +353,7 @@ pub fn scrypt_check(password: &str, hashed_value: &str) -> Result<bool, &'static
             // Parse the parameters - the size of them depends on the if we are using the compact or
             // expanded format
             let pvec = match iter.next() {
-                Some(pstr) => match base64::decode(pstr) {
+                Some(pstr) => match base64::engine::general_purpose::STANDARD.decode(pstr) {
                     Ok(x) => x,
                     Err(_) => return Err(ERR_STR),
                 },
@@ -386,7 +386,7 @@ pub fn scrypt_check(password: &str, hashed_value: &str) -> Result<bool, &'static
 
     // Salt
     let salt = match iter.next() {
-        Some(sstr) => match base64::decode(sstr) {
+        Some(sstr) => match base64::engine::general_purpose::STANDARD.decode(sstr) {
             Ok(salt) => salt,
             Err(_) => return Err(ERR_STR),
         },
@@ -395,7 +395,7 @@ pub fn scrypt_check(password: &str, hashed_value: &str) -> Result<bool, &'static
 
     // Hashed value
     let hash = match iter.next() {
-        Some(hstr) => match base64::decode(hstr) {
+        Some(hstr) => match base64::engine::general_purpose::STANDARD.decode(hstr) {
             Ok(hash) => hash,
             Err(_) => return Err(ERR_STR),
         },

--- a/src/sha3.rs
+++ b/src/sha3.rs
@@ -449,7 +449,6 @@ impl Clone for Sha3 {
 #[cfg(test)]
 mod tests {
     use digest::Digest;
-    use hex::{self, ToHex};
     use sha3::{Sha3, Sha3Mode};
 
     struct Test {
@@ -471,8 +470,8 @@ mod tests {
             let mut out_str = vec![0u8; t.output_str.len() / 2];
 
             sh.result(&mut out_str);
-            println!("{}", &out_str.to_hex());
-            assert!(&out_str.to_hex() == t.output_str);
+            println!("{}", hex::encode(&out_str));
+            assert!(hex::encode(&out_str) == t.output_str);
 
             sh.reset();
         }
@@ -491,7 +490,7 @@ mod tests {
 
             sh.result(&mut out_str);
 
-            assert!(&out_str.to_hex() == t.output_str);
+            assert!(hex::encode(&out_str) == t.output_str);
 
             sh.reset();
         }


### PR DESCRIPTION
Some further dependency upgrades. `rand` is stuck at 0.4 (it's currently at 0.8.5) because of some breaking changes to reseedable RNG traits that would cause breaking changes to exposed APIs in this crate as well, which sort of defeats the purpose of maintaining this. 